### PR TITLE
Replacing webkitAudioContext with AudioContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ More on binaural beats <a target="_blank" href="http://en.wikipedia.org/wiki/Bin
 
 ### Basic Usage
     // Create a new AudioContext to connect to
-    var context = new webkitAudioContext()
+    var context = new AudioContext()
 
     // Create a BinauralBeat instance, options is a hash with the below defaults if nothing is provided.
     var bBeat = new BinauralBeat(context, options{pitch: 440, beatRate: 5, waveType: 0, compressNodes: false});

--- a/examples/js/application.coffee
+++ b/examples/js/application.coffee
@@ -1,5 +1,6 @@
 # Binaural Setup
-context = new webkitAudioContext()
+AudioContext = window.AudioContext || window.webkitAudioContext;
+context = new AudioContext()
 bBeat = new BinauralBeat(context)
 leftChannel = bBeat.getChannel(0)
 rightChannel = bBeat.getChannel(1)

--- a/examples/js/application.js
+++ b/examples/js/application.js
@@ -1,7 +1,9 @@
 (function() {
   var analyserLeft, analyserRight, bBeat, canvas_height, canvas_width, context, gain, leftChannel, points, renderer, rightChannel, run, scale_left, scale_right, started, visualizerLeft, visualizerRight;
 
-  context = new webkitAudioContext();
+  AudioContext = window.AudioContext || window.webkitAudioContext;
+
+  context = new AudioContext();
 
   bBeat = new BinauralBeat(context);
 


### PR DESCRIPTION
webkitAudioContext (used in demo and documentation) is now deprecated, so have replaced with AudioContext (with a fallback for older WebKit browsers).